### PR TITLE
Add debug flag for API request logging

### DIFF
--- a/carrots/main.go
+++ b/carrots/main.go
@@ -404,7 +404,7 @@ func makeGitHubRequestWithAccept(url, token, acceptHeader string) ([]byte, error
 			if k == "Authorization" {
 				fmt.Fprintf(os.Stderr, "  %s: Bearer [REDACTED]\n", k)
 			} else {
-				fmt.Fprintf(os.Stderr, "  %s: %s\n", k, v)
+				fmt.Fprintf(os.Stderr, "  %s: %s\n", k, strings.Join(v, ", "))
 			}
 		}
 		fmt.Fprintf(os.Stderr, "\n")
@@ -427,7 +427,7 @@ func makeGitHubRequestWithAccept(url, token, acceptHeader string) ([]byte, error
 		fmt.Fprintf(os.Stderr, "Status: %d %s\n", resp.StatusCode, resp.Status)
 		fmt.Fprintf(os.Stderr, "Headers:\n")
 		for k, v := range resp.Header {
-			fmt.Fprintf(os.Stderr, "  %s: %s\n", k, v)
+			fmt.Fprintf(os.Stderr, "  %s: %s\n", k, strings.Join(v, ", "))
 		}
 		fmt.Fprintf(os.Stderr, "\nBody:\n")
 


### PR DESCRIPTION
…ponses

Adds a new -debug flag that enables detailed logging of all GitHub API interactions. When enabled, the flag pretty-prints:
- Request method, URL, and headers (with token redacted)
- Response status, headers, and JSON body (formatted with indentation)

This is useful for troubleshooting API issues and understanding the data flow when working with GitHub pull requests and comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `-debug` command-line flag that enables verbose API request and response logging to standard error for troubleshooting. Logged details include method, URL, headers (Authorization redacted), and response status. JSON request/response bodies are pretty-printed when possible. Diagnostic output applies across API request paths and is emitted only when the flag is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->